### PR TITLE
Add an update method to the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 
+BIN := ./node_modules/.bin
+MOCHA := $(BIN)/mocha
+
+node_modules: package.json
+	@npm install
+
 test:
-	@./node_modules/.bin/mocha \
-		--require should \
-		--reporter spec
+	@$(MOCHA)
 
 .PHONY: test

--- a/Readme.md
+++ b/Readme.md
@@ -1,31 +1,53 @@
 
 # node-netrc
 
-  Higher-level `~/.netrc` parser
+> Higher-level `~/.netrc` parser
+
 
 ## Example
 
 ```js
 var netrc = require('node-netrc');
+
+// read auth from ~/.netrc
 var auth = netrc('api.github.com');
 auth.login // ...
 auth.password // ...
+
+// merge new config into ~/.netrc
+netrc.update('api.github.com', {
+  login: 'user',
+  password: 'pass'
+});
 ```
+
 
 ## API
 
-### `netrc([host])`
+### netrc([host])
 
 Return the `login` and `password` details of `host`. Or return `false`.
 
 If no `host`, return all the hosts.
 
+### netrc.update(host, data)
+
+Updates the netrc with the given `data` for `host`. (`data` usually contains
+`login` and `password`, but any given props will be written)
+
+If `data` is empty, the given `host` will be removed from the file.
+
+**NOTE:** this method merges data with what is already in place, it will **not**
+affect any other hosts.
+
+
 ## Testing
 
-    npm install
-    make test
+```sh
+npm install
+make test
+```
 
-> Note: you'll need `raw.github.com` & `api.github.com` set in your `~/.netrc` for the tests to function properly.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,25 +1,59 @@
+
 /**
  * Module Dependencies
  */
 
-var hosts = require('netrc')();
+var netrc = require('netrc');
+var path = require('path');
+var fs = require('fs');
+var env = process.env;
 
 /**
- * Export `netrc`
+ * Locals.
  */
 
-module.exports = netrc;
+var home = env.HOME || env.HOMEPATH;
 
 /**
- * Initialize `netrc`
+ * Exports.
+ */
+
+exports = module.exports = read;
+exports.update = update;
+exports.file = path.join(home, '.netrc');
+
+/**
+ * Read the contents of $HOME/.netrc. The default behavior is to return the
+ * entire file's parsed contents. If a `host` is specified, it will only return
+ * that host's config.
+ *
+ * @param {String} [host]
+ * @return {Object}
+ */
+
+function read(host) {
+  var hosts = netrc(exports.file);
+  if (!host) return hosts;
+  if (host in hosts) return hosts[host];
+  return false;
+}
+
+/**
+ * Update $HOME/.netrc to have the given `host` config (ie: `data`)
+ *
+ * NOTE: this reads from disk just before writing again, so it is a merge
+ *       and not a full replacement!
  *
  * @param {String} host
- * @return {Object}
- * @api public
+ * @param {Object} data
  */
 
-function netrc(host) {
-  if (!host) return hosts;
-  else if (hosts[host]) return hosts[host];
-  else return false;
+function update(host, data) {
+  var hosts = netrc(exports.file);
+  if (data) {
+    hosts[host] = data;
+  } else {
+    delete hosts[host];
+  }
+  fs.writeFileSync(exports.file, netrc.format(hosts), 'utf8');
 }

--- a/package.json
+++ b/package.json
@@ -4,15 +4,11 @@
   "description": "Higher-level ~/.netrc parser",
   "keywords": [],
   "author": "Matthew Mueller <mattmuelle@gmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/MatthewMueller/node-netrc"
-  },
+  "repository": "duojs/node-netrc",
   "dependencies": {
     "netrc": "^0.1.3"
   },
   "devDependencies": {
     "mocha": "*"
-  },
-  "main": "index"
+  }
 }

--- a/test/fixtures/complex
+++ b/test/fixtures/complex
@@ -1,0 +1,8 @@
+
+machine api.github.com
+  login user1
+  password pass1
+
+machine raw.github.com
+  login user2
+  password pass2

--- a/test/fixtures/simple
+++ b/test/fixtures/simple
@@ -1,0 +1,4 @@
+
+machine api.github.com
+  login user
+  password pass

--- a/test/node-netrc.js
+++ b/test/node-netrc.js
@@ -111,6 +111,22 @@ describe('netrc([host])', function() {
         }
       });
     });
+
+    it('should delete the given host', function () {
+      // copy fixture file to tmp dir
+      fs.writeFileSync(tmp, fs.readFileSync(fixture('complex')), 'utf8');
+
+      // write to the tmp file
+      netrc.file = tmp;
+      netrc.update('raw.github.com');
+
+      assert.deepEqual(netrc(), {
+        'api.github.com': {
+          login: 'user1',
+          password: 'pass1'
+        }
+      });
+    });
   });
 
   describe('.file', function () {

--- a/test/node-netrc.js
+++ b/test/node-netrc.js
@@ -1,30 +1,123 @@
+
 /**
  * Module Dependencies
  */
 
 var assert = require('assert');
+var path = require('path');
 var netrc = require('..');
+var fs = require('fs');
+var os = require('os');
+
+var fixture = path.resolve.bind(path, __dirname, 'fixtures');
+var tmp = path.resolve(os.tmpdir(), '.netrc');
 
 /**
  * Tests
  */
 
-describe('netrc', function() {
+describe('netrc([host])', function() {
+  var defaultFile = netrc.file;
+
+  afterEach(function() {
+    netrc.file = defaultFile;
+    if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
+  });
 
   it('should return a host', function() {
+    netrc.file = fixture('simple');
+
     var obj = netrc('api.github.com');
+
     assert(obj.password);
     assert(obj.login);
-  })
+  });
 
   it('should return false if no host found', function() {
-    assert(false == netrc('blah.com'));
-  })
+    netrc.file = fixture('simple');
+
+    var obj = netrc('blah.com');
+
+    assert.strictEqual(obj, false);
+  });
 
   it('should return all hosts if no host given', function() {
-    var obj = netrc();
-    assert(obj['api.github.com']);
-    assert(obj['raw.github.com']);
-  })
+    netrc.file = fixture('complex');
 
+    var obj = netrc();
+
+    assert.deepEqual(obj, {
+      'api.github.com': {
+        login: 'user1',
+        password: 'pass1'
+      },
+      'raw.github.com': {
+        login: 'user2',
+        password: 'pass2'
+      }
+    });
+  });
+
+  it('should return an empty object', function() {
+    netrc.file = fixture('empty');
+
+    var obj = netrc();
+
+    assert.deepEqual(obj, {});
+  });
+
+  describe('.update(host, data)', function() {
+    it('should write to the given file', function () {
+      netrc.file = tmp;
+      var obj = netrc();
+      netrc.update('api.github.com', { password: 'abc123' });
+      assert.strictEqual(netrc('api.github.com').password, 'abc123');
+    });
+
+    it('should add to the file', function () {
+      // copy fixture file to tmp dir
+      fs.writeFileSync(tmp, fs.readFileSync(fixture('simple')), 'utf8');
+
+      // write to the tmp file
+      netrc.file = tmp;
+      netrc.update('raw.github.com', { password: 'abc123' });
+
+      assert.deepEqual(netrc(), {
+        'api.github.com': {
+          login: 'user',
+          password: 'pass'
+        },
+        'raw.github.com': {
+          password: 'abc123'
+        }
+      });
+    });
+
+    it('should merge with the file', function () {
+      // copy fixture file to tmp dir
+      fs.writeFileSync(tmp, fs.readFileSync(fixture('complex')), 'utf8');
+
+      // write to the tmp file
+      netrc.file = tmp;
+      netrc.update('raw.github.com', { password: 'abc123' });
+
+      assert.deepEqual(netrc(), {
+        'api.github.com': {
+          login: 'user1',
+          password: 'pass1'
+        },
+        'raw.github.com': {
+          password: 'abc123'
+        }
+      });
+    });
+  });
+
+  describe('.file', function () {
+    var home = process.env.HOME || process.env.HOMEPATH;
+
+    it('should be in the home directory', function() {
+      assert.equal(netrc.file, path.join(home, '.netrc'));
+    });
+  });
 });


### PR DESCRIPTION
This adds `netrc.update(host, [data])` to the API. (retains backwards-compatibility)

This new method merges the given `host` and `data` pair into the given `.netrc` file:

``` js
netrc.update('api.github.com', {
  login: 'x-oauth-basic',
  password: 'new token'
});
```

In addition, `netrc.file` is exposed (allowing us to programmatically set that during tests only) but undocumented.

This new method can also be used to delete an entry from the `.netrc`:

``` js
netrc.update('api.github.com', null); // excluding the 2nd argument has the same result
```

Tests have been added to cover all these new features.
